### PR TITLE
Fix potential overload ambiguity in Mesh constructor calls

### DIFF
--- a/examples/3DHcurlWeakScaling.cpp
+++ b/examples/3DHcurlWeakScaling.cpp
@@ -118,7 +118,7 @@ int main (int argc, char *argv[])
 //      Element::Type type = Element::TETRAHEDRON;
     Element::Type type = Element::HEXAHEDRON;
 
-    auto mesh = make_unique<Mesh>(n, n, n, type, 1);
+    auto mesh = make_unique<Mesh>(n, n, n, type, true);
 
     const int nDimensions = mesh->Dimension();
 

--- a/examples/3DHdivWeakScaling.cpp
+++ b/examples/3DHdivWeakScaling.cpp
@@ -120,7 +120,7 @@ int main (int argc, char *argv[])
 //      Element::Type type = Element::TETRAHEDRON;
         Element::Type type = Element::HEXAHEDRON;
 
-        auto mesh = make_unique<Mesh>(n, n, n, type, 1);
+        auto mesh = make_unique<Mesh>(n, n, n, type, true);
 
         const int n_el_c = mesh->GetNE();
         Array<int> partitioning(n_el_c);

--- a/examples/EmbeddedMeshPartitionerDemo.cpp
+++ b/examples/EmbeddedMeshPartitionerDemo.cpp
@@ -153,7 +153,7 @@ int main (int argc, char *argv[])
                           << ", falling back to default behavior." << std::endl;
                 std::cout << "Generating cube mesh with 8 hexahedral elements.\n";
             }
-            mesh = make_unique<Mesh>(2, 2, 2, Element::HEXAHEDRON, 1);
+            mesh = make_unique<Mesh>(2, 2, 2, Element::HEXAHEDRON, true);
             // Change mesh attribute of bottom half of cube
             for ( int i = 0; i < 4; i++)
                 mesh->GetElement(i)->SetAttribute(2);

--- a/examples/Upscaling0FormSpectral.cpp
+++ b/examples/Upscaling0FormSpectral.cpp
@@ -136,7 +136,7 @@ int main (int argc, char *argv[])
                           << std::endl << "Generating structured mesh."
                           << std::endl;
             }
-            mesh = make_unique<Mesh>(2, 2, 2, Element::HEXAHEDRON, 1);
+            mesh = make_unique<Mesh>(2, 2, 2, Element::HEXAHEDRON, true);
         }
         ess_attr.SetSize(mesh->bdr_attributes.Max());
         ess_attr = 0;

--- a/examples/Upscaling2FormAMGe.cpp
+++ b/examples/Upscaling2FormAMGe.cpp
@@ -106,7 +106,7 @@ int main (int argc, char *argv[])
                           << std::endl << "Generating structured mesh."
                           << std::endl;
             }
-            mesh = make_unique<Mesh>(2, 2, 2, Element::HEXAHEDRON, 1);
+            mesh = make_unique<Mesh>(2, 2, 2, Element::HEXAHEDRON, true);
         }
         ess_attr.SetSize(mesh->bdr_attributes.Max());
         ess_attr = 1;

--- a/examples/Upscaling2FormSpectralAMGe.cpp
+++ b/examples/Upscaling2FormSpectralAMGe.cpp
@@ -123,7 +123,7 @@ int main (int argc, char *argv[])
                           << std::endl << "Generating structured mesh."
                           << std::endl;
             }
-            mesh = make_unique<Mesh>(2, 2, 2, Element::HEXAHEDRON, 1);
+            mesh = make_unique<Mesh>(2, 2, 2, Element::HEXAHEDRON, true);
         }
         ess_attr.SetSize(mesh->bdr_attributes.Max());
         ess_attr = 1;

--- a/examples/testing_helpers/Build3DHexMesh.hpp
+++ b/examples/testing_helpers/Build3DHexMesh.hpp
@@ -24,7 +24,7 @@ namespace testhelpers
 
 std::unique_ptr<mfem::Mesh> Build3DHexMesh()
 {
-    return make_unique<mfem::Mesh>(2,2,2,mfem::Element::HEXAHEDRON,1);
+    return make_unique<mfem::Mesh>(2, 2, 2, mfem::Element::HEXAHEDRON, true);
 }
 
 }// namespace testhelpers

--- a/testsuite/UpscalingGeneralForm.cpp
+++ b/testsuite/UpscalingGeneralForm.cpp
@@ -222,7 +222,7 @@ int main (int argc, char *argv[])
                           << ", falling back to default behavior." << std::endl;
                 std::cout << "Generating cube mesh with 8 hexahedral elements.\n";
             }
-            mesh = make_unique<Mesh>(2, 2, 2, Element::HEXAHEDRON, 1);
+            mesh = make_unique<Mesh>(2, 2, 2, Element::HEXAHEDRON, true);
             for (int i(1); i < nbdr-1; ++i)
                 ess_zeros[i] = 1;
             nat_one[0] = 1;

--- a/testsuite/test_GeometricBoxPartitioner.cpp
+++ b/testsuite/test_GeometricBoxPartitioner.cpp
@@ -102,10 +102,10 @@ int main(int argc, char * argv[])
     if (meshfile == "GENERATE_MESH")
     {
         if (dimension == 2)
-            mesh = make_unique<Mesh>(x_elements, y_elements, Element::QUADRILATERAL, 1);
+            mesh = make_unique<Mesh>(x_elements, y_elements, Element::QUADRILATERAL, true);
         else
             mesh = make_unique<Mesh>(x_elements, y_elements, z_elements,
-                                     Element::HEXAHEDRON, 1);
+                                     Element::HEXAHEDRON, true);
     }
     else
     {

--- a/testsuite/twentyseven.cpp
+++ b/testsuite/twentyseven.cpp
@@ -246,24 +246,24 @@ int main (int argc, char *argv[])
     if (argument == "discedge")
     {
         // create 39-element serial mesh
-        Mesh mesh(3, 3, 4, Element::HEXAHEDRON, 1);
+        Mesh mesh(3, 3, 4, Element::HEXAHEDRON, true);
         pmesh = make_shared<ParMesh>(comm, mesh);
     }
     else if (argument == "tet")
     {
         // create 48-element serial tetrahedral mesh
-        Mesh mesh(2, 2, 2, Element::TETRAHEDRON, 1);
+        Mesh mesh(2, 2, 2, Element::TETRAHEDRON, true);
         pmesh = make_shared<ParMesh>(comm, mesh);
     }
     else if (argument == "sv2")
     {
-        Mesh mesh(2, 2, 2, Element::HEXAHEDRON, 1);
+        Mesh mesh(2, 2, 2, Element::HEXAHEDRON, true);
         pmesh = make_shared<ParMesh>(comm, mesh);
     }
     else
     {
         // create 27-element serial mesh
-        Mesh mesh(3, 3, 3, Element::HEXAHEDRON, 1);
+        Mesh mesh(3, 3, 3, Element::HEXAHEDRON, true);
         pmesh = make_shared<ParMesh>(comm, mesh);
     }
     std::vector<shared_ptr<AgglomeratedTopology> > topology(2);

--- a/testsuite/unstructuredDarcy.cpp
+++ b/testsuite/unstructuredDarcy.cpp
@@ -132,7 +132,7 @@ int main (int argc, char *argv[])
                           << ", falling back to default behavior." << std::endl;
                 std::cout << "Generating cube mesh with 8 hexahedral elements.\n";
             }
-            mesh = make_unique<Mesh>(2, 2, 2, Element::HEXAHEDRON, 1);
+            mesh = make_unique<Mesh>(2, 2, 2, Element::HEXAHEDRON, true);
         }
 
         for (int l=0; l<ser_ref_levels; l++)


### PR DESCRIPTION
Replace "1" in several `Mesh()` constructors with "true".

On my local machine, I was getting the compilation error `call of overloaded Mesh() is ambiguous`. This is probably specific to my compiler and my (bleeding edge) MFEM installation, but I think the changes here are a slight improvement either way.