### PR TITLE
Alternative rescaling

### DIFF
--- a/examples/MultigridTestDarcy_Hybrid.cpp
+++ b/examples/MultigridTestDarcy_Hybrid.cpp
@@ -286,10 +286,10 @@ int main (int argc, char *argv[])
                 level_nElements[ilevel+1],
                 partitioning);
             topology[ilevel+1] =
-                topology[ilevel]->CoarsenLocalPartitioning(partitioning, 0, 0,0);
+                topology[ilevel]->CoarsenLocalPartitioning(partitioning, 0, 0,
+                                                           nDimensions == 2 ? 0 : 2);
         }
     }
-    std::cout<<"num bdr faces = "<<topology[1]->FacetBdrAttribute().NumNonZeroElems()<<"\n";
 
     if (print_progress_report)
         std::cout << "-- Successfully agglomerated topology.\n\n"

--- a/examples/MultigridTestDarcy_Hybrid.cpp
+++ b/examples/MultigridTestDarcy_Hybrid.cpp
@@ -286,7 +286,7 @@ int main (int argc, char *argv[])
                 level_nElements[ilevel+1],
                 partitioning);
             topology[ilevel+1] =
-                topology[ilevel]->CoarsenLocalPartitioning(partitioning, 0, 0);
+                topology[ilevel]->CoarsenLocalPartitioning(partitioning, 0, 0, 2);
         }
     }
 
@@ -305,13 +305,21 @@ int main (int argc, char *argv[])
         Timer tot_timer = TimeManager::AddTimer(
             "DeRhamSequence Construction -- Total");
 
-        sequence[0] = make_shared<DeRhamSequence3D_FE>(
-            topology[0], pmesh.get(), feorder);
+        if (nDimensions == 3)
+        {
+            sequence[0] = make_shared<DeRhamSequence3D_FE>(
+                        topology[0], pmesh.get(), feorder);
+        }
+        else
+        {
+            sequence[0] = make_shared<DeRhamSequence2D_Hdiv_FE>(
+                        topology[0], pmesh.get(), feorder);
+        }
 
         DRSequence_FE = sequence[0]->FemSequence();
         PARELAG_ASSERT(DRSequence_FE);
 
-        constexpr int jFormStart = 0;
+        const int jFormStart = nDimensions - 1;
         sequence[0]->SetjformStart(jFormStart);
 
         DRSequence_FE->ReplaceMassIntegrator(
@@ -324,24 +332,12 @@ int main (int argc, char *argv[])
 
         mfem::Array<mfem::Coefficient *> L2coeff;
         mfem::Array<mfem::VectorCoefficient *> Hdivcoeff;
-        mfem::Array<mfem::VectorCoefficient *> Hcurlcoeff;
-        mfem::Array<mfem::Coefficient *> H1coeff;
-        fillVectorCoefficientArray(nDimensions, upscalingOrder, Hcurlcoeff);
         fillVectorCoefficientArray(nDimensions, upscalingOrder, Hdivcoeff);
         fillCoefficientArray(nDimensions, upscalingOrder, L2coeff);
-        fillCoefficientArray(nDimensions, upscalingOrder+1, H1coeff);
 
         std::vector<unique_ptr<MultiVector>>
             targets(sequence[0]->GetNumberOfForms());
-        int jform(0);
-
-        targets[jform] =
-            DRSequence_FE->InterpolateScalarTargets(jform, H1coeff);
-        ++jform;
-
-        targets[jform] =
-            DRSequence_FE->InterpolateVectorTargets(jform, Hcurlcoeff);
-        ++jform;
+        int jform(nDimensions-1);
 
         targets[jform] =
             DRSequence_FE->InterpolateVectorTargets(jform,Hdivcoeff);
@@ -353,8 +349,6 @@ int main (int argc, char *argv[])
 
         freeCoeffArray(L2coeff);
         freeCoeffArray(Hdivcoeff);
-        freeCoeffArray(Hcurlcoeff);
-        freeCoeffArray(H1coeff);
 
         mfem::Array<MultiVector*> targets_in(targets.size());
         for (int ii = 0; ii < targets_in.Size(); ++ii)
@@ -533,6 +527,8 @@ int main (int argc, char *argv[])
     		"Solver Parameters").Get<double>("Relative tolerance");
     const double atol = solver_list.Sublist(
     		"Solver Parameters").Get<double>("Absolute tolerance");
+    const int rescale_iter = prec_list.Sublist(prec_type).Sublist(
+            "Solver Parameters").Get<int>("RescaleIteration");
 
     auto solver_state = prec_factory->GetDefaultState();
     solver_state->SetDeRhamSequence(sequence[start_level]);
@@ -549,7 +545,7 @@ int main (int argc, char *argv[])
     // Number of smoothing steps in the generation of the rescaling vector
     // Such a rescaling can potentially improve the efficiency of the solver
     // If it is set to 0, then the original hybridized system is solved
-    solver_state->SetExtraParameter("RescaleIteration",20);
+    solver_state->SetExtraParameter("RescaleIteration",rescale_iter);
 
     // Scales of element H(div) mass matrices for the problem being solved
     // If not provided, the scale is treated as 1.0.

--- a/examples/MultigridTestDarcy_Hybrid.cpp
+++ b/examples/MultigridTestDarcy_Hybrid.cpp
@@ -286,9 +286,10 @@ int main (int argc, char *argv[])
                 level_nElements[ilevel+1],
                 partitioning);
             topology[ilevel+1] =
-                topology[ilevel]->CoarsenLocalPartitioning(partitioning, 0, 0, 2);
+                topology[ilevel]->CoarsenLocalPartitioning(partitioning, 0, 0,0);
         }
     }
+    std::cout<<"num bdr faces = "<<topology[1]->FacetBdrAttribute().NumNonZeroElems()<<"\n";
 
     if (print_progress_report)
         std::cout << "-- Successfully agglomerated topology.\n\n"

--- a/src/amge/DeRhamSequence.cpp
+++ b/src/amge/DeRhamSequence.cpp
@@ -1783,6 +1783,7 @@ void DeRhamSequence::ComputeCoarseTracesWithTargets(int jform)
 
     //========== FIRST LOOP: Compute SVDs and set AE_ndofs ===========//
     // my_p and mass get filled in here
+    int i_count = 0;
     for (int iAE(0); iAE < nAE; ++iAE)
     {
         if (AE_TrueAE.IsShared(iAE) == -1 )
@@ -1847,6 +1848,10 @@ void DeRhamSequence::ComputeCoarseTracesWithTargets(int jform)
                 if (s(i) < s_max_tol)
                     break;
             }
+            if (i > 0)
+                i_count++;
+//            s.Print();
+//std::cout<<"facet "<< iAE<<": "<<i<<"\n";
             AE_ndofs[iAE] = i+1;
 
             double pv_dot_pv = inner_product(loc_pv, loc_pv);
@@ -1892,6 +1897,7 @@ void DeRhamSequence::ComputeCoarseTracesWithTargets(int jform)
             mass.SetElementalMatrix(iAE, std::move(cElemMass) );
         }
     }
+    std::cout<<"number of faces with i > 0 = "<<i_count<<"\n";
 
     {
         Array<int> tmp(AE_ndofs, nAE);

--- a/src/amge/DeRhamSequence.cpp
+++ b/src/amge/DeRhamSequence.cpp
@@ -681,6 +681,13 @@ std::shared_ptr<DeRhamSequence> DeRhamSequence::Coarsen()
                             *(coarser_sequence->Targets_[jform]));
     }
 
+    // Coarsen constant one representation
+    MultiVector fine_const(L2_const_rep_.GetData(), 1, L2_const_rep_.Size());
+    mfem::Vector& coarse_rep = coarser_sequence->GetL2ConstRepresentation();
+    coarse_rep.SetSize(coarser_sequence->Dof_[nForms_-1]->GetNDofs());
+    MultiVector coarse_const(coarse_rep.GetData(), 1, coarse_rep.Size());
+    Pi_[nForms_-1]->Project(fine_const, coarse_const);
+
     return coarser_sequence;
 }
 

--- a/src/amge/DeRhamSequence.cpp
+++ b/src/amge/DeRhamSequence.cpp
@@ -1783,7 +1783,6 @@ void DeRhamSequence::ComputeCoarseTracesWithTargets(int jform)
 
     //========== FIRST LOOP: Compute SVDs and set AE_ndofs ===========//
     // my_p and mass get filled in here
-    int i_count = 0;
     for (int iAE(0); iAE < nAE; ++iAE)
     {
         if (AE_TrueAE.IsShared(iAE) == -1 )
@@ -1848,10 +1847,6 @@ void DeRhamSequence::ComputeCoarseTracesWithTargets(int jform)
                 if (s(i) < s_max_tol)
                     break;
             }
-            if (i > 0)
-                i_count++;
-//            s.Print();
-//std::cout<<"facet "<< iAE<<": "<<i<<"\n";
             AE_ndofs[iAE] = i+1;
 
             double pv_dot_pv = inner_product(loc_pv, loc_pv);
@@ -1897,7 +1892,6 @@ void DeRhamSequence::ComputeCoarseTracesWithTargets(int jform)
             mass.SetElementalMatrix(iAE, std::move(cElemMass) );
         }
     }
-    std::cout<<"number of faces with i > 0 = "<<i_count<<"\n";
 
     {
         Array<int> tmp(AE_ndofs, nAE);

--- a/src/amge/DeRhamSequence.hpp
+++ b/src/amge/DeRhamSequence.hpp
@@ -417,6 +417,10 @@ public:
     GetElementalMassMatrices(int iform,
                              AgglomeratedTopology::Entity icodim);
 
+    /// Get the representation of constant one function in L2 (dim-form)
+    const mfem::Vector& GetL2ConstRepresentation() const { return L2_const_rep_; }
+    mfem::Vector& GetL2ConstRepresentation() { return L2_const_rep_; }
+
     ///@}
     /// \name Exploit the linked list
     ///@{
@@ -669,6 +673,9 @@ protected:
 
     /// The cochain projector from this level to the coarser one
     std::vector<std::unique_ptr<CochainProjector>> Pi_;
+
+    /// Representation of constant one function in L2 (dim-form)
+    mfem::Vector L2_const_rep_;
 
     /// The next coarsest sequence in the hierarchy
     std::weak_ptr<DeRhamSequence> CoarserSequence_;

--- a/src/amge/DeRhamSequenceFE.cpp
+++ b/src/amge/DeRhamSequenceFE.cpp
@@ -662,6 +662,9 @@ DeRhamSequence3D_FE::DeRhamSequence3D_FE(
         assembleLocalMass();
         assembleDerivative();
     }
+
+    mfem::ConstantCoefficient one(1.0);
+    ProjectCoefficient(nDimensions, one, L2_const_rep_);
 }
 
 DeRhamSequence3D_FE::~DeRhamSequence3D_FE()
@@ -739,6 +742,9 @@ DeRhamSequence2D_Hdiv_FE::DeRhamSequence2D_Hdiv_FE(
         assembleLocalMass();
         assembleDerivative();
     }
+
+    mfem::ConstantCoefficient one(1.0);
+    ProjectCoefficient(nDimensions, one, L2_const_rep_);
 }
 
 void DeRhamSequence2D_Hdiv_FE::computePVTraces(

--- a/src/amge/HybridHdivL2.cpp
+++ b/src/amge/HybridHdivL2.cpp
@@ -233,8 +233,6 @@ void HybridHdivL2::AssembleHybridSystem()
     // Determine whether to construct rescaling vector (CC^T)^{-1}CB^T1
     // (rescaling works in fine level or if number of HdivDof on each facet = 1)
     const bool make_rescale = !IsSameOrient || (nFacet == facet_HdivDof.NumCols());
-std::cout<<"nFacet: "<< nFacet<<" num Hdiv dofs: "<<facet_HdivDof.NumCols()<<"\n";
-    std::cout<<"rescaling"<< (make_rescale?" is ":" is NOT ")<<"generating\n";
     mfem::Vector CCT_diag(make_rescale ? HybridSystem->NumRows() : 0);
     mfem::Vector CBT1(CCT_diag.Size());
     CCT_diag = 0.0;

--- a/src/amge/HybridHdivL2.cpp
+++ b/src/amge/HybridHdivL2.cpp
@@ -45,7 +45,8 @@ HybridHdivL2::HybridHdivL2(const std::shared_ptr<DeRhamSequence>& sequence,
     AinvCT(0),
     Ainv_f(0),
     Ainv(0),
-    A_el(0)
+    A_el(0),
+    CCT_inv_CBT1(0)
 {
     // Mass matrix for L2 space
     W = sequence->ComputeMassOperator(nDimension);
@@ -228,6 +229,11 @@ void HybridHdivL2::AssembleHybridSystem()
 
     Array<int> HdivGlobalToLocalMap(elem_HdivDof.Width());
     HdivGlobalToLocalMap = -1;
+
+    mfem::Vector CCT_diag(HybridSystem->NumRows());
+    mfem::Vector CBT1(HybridSystem->NumRows());
+    CCT_diag = 0.0;
+    CBT1 = 0.0;
 
     for (int elem = 0; elem < nElem; ++elem)
     {
@@ -413,8 +419,35 @@ void HybridHdivL2::AssembleHybridSystem()
                                    *tmpHybrid_el,
                                    1);
 
-        A_el[elem] = std::move(tmpAloc);
+        // Save CCT and CBT1
+        mfem::DenseMatrix CCT(nMultiplierDofLoc);
+        mfem::MultAAt(ClocT, CCT);
+        mfem::Vector CCT_diag_local;
+        CCT.GetDiag(CCT_diag_local);
+
+        mfem::Vector const_one(nHdivDofLoc+nL2DofLoc);
+        for (int i = 0; i < nHdivDofLoc; ++i)
+        {
+            const_one[i] = 0.0;
+        }
+        for (int i = 0; i < nL2DofLoc; ++i)
+        {
+            const_one[nHdivDofLoc+i] = 1.0;
+        }
+        mfem::Vector BTone(nHdivDofLoc+nL2DofLoc);
+        tmpAloc->Mult(const_one, BTone);
+
+        mfem::Vector CBT1_local(nMultiplierDofLoc);
+        ClocT.Mult(BTone, CBT1_local);
+
+        for (int i = 0; i < nMultiplierDofLoc; ++i)
+        {
+            CCT_diag[MultiplierDofLoc[i]] += CCT_diag_local[i];
+            CBT1[MultiplierDofLoc[i]] += CBT1_local[i];
+        }
+
         // Save the factorization of [M B^T;B 0] for solution recovery purpose
+        A_el[elem] = std::move(tmpAloc);
         Ainv[elem] = std::move(solver);
 
         // Save the element matrix [M B^T;B 0]^-1[C 0]^T for solution
@@ -460,6 +493,19 @@ void HybridHdivL2::AssembleHybridSystem()
     		int mult_dof = j_HdivDof_Multiplier[i_HdivDof_Multiplier[i]];
     		ess_MultiplierDofs[mult_dof] = 1;
     	}
+
+    // Assemble global rescaling vector (CC^T)^{-1}CB^T 1
+    mfem::Vector CCT_diag_global(MultiplierTrueMultiplier.GetTrueLocalSize());
+    MultiplierTrueMultiplier.Assemble(CCT_diag, CCT_diag_global);
+
+    mfem::Vector CBT1_global(MultiplierTrueMultiplier.GetTrueLocalSize());
+    MultiplierTrueMultiplier.Assemble(CBT1, CBT1_global);
+
+    CCT_inv_CBT1.SetSize(MultiplierTrueMultiplier.GetTrueLocalSize());
+    for (int i = 0; i < CCT_inv_CBT1.Size(); ++i)
+    {
+        CCT_inv_CBT1[i] = CBT1_global[i] / CCT_diag_global[i];
+    }
 }
 
 // TODO: impose nonzero boundary condition for u.n

--- a/src/amge/HybridHdivL2.cpp
+++ b/src/amge/HybridHdivL2.cpp
@@ -47,6 +47,7 @@ HybridHdivL2::HybridHdivL2(const std::shared_ptr<DeRhamSequence>& sequence,
     Ainv_f(0),
     Ainv(0),
     A_el(0),
+    L2_const_rep_(sequence->GetL2ConstRepresentation()),
     CCT_inv_CBT1(0)
 {
     // Mass matrix for L2 space
@@ -431,17 +432,21 @@ void HybridHdivL2::AssembleHybridSystem()
             mfem::Vector CCT_diag_local;
             CCT.GetDiag(CCT_diag_local);
 
-            mfem::Vector const_one(nHdivDofLoc+nL2DofLoc);
+            mfem::Vector const_one;
+            L2_const_rep_.GetSubVector(L2DofLoc, const_one);
+
+            mfem::Vector zero_one(nHdivDofLoc+nL2DofLoc);
             for (int i = 0; i < nHdivDofLoc; ++i)
             {
-                const_one[i] = 0.0;
+                zero_one[i] = 0.0;
             }
             for (int i = 0; i < nL2DofLoc; ++i)
             {
-                const_one[nHdivDofLoc+i] = 1.0;
+                zero_one[nHdivDofLoc+i] = const_one[i];
             }
+
             mfem::Vector BTone(nHdivDofLoc+nL2DofLoc);
-            tmpAloc->Mult(const_one, BTone);
+            tmpAloc->Mult(zero_one, BTone);
 
             mfem::Vector CBT1_local(nMultiplierDofLoc);
             ClocT.Mult(BTone, CBT1_local);

--- a/src/amge/HybridHdivL2.hpp
+++ b/src/amge/HybridHdivL2.hpp
@@ -67,6 +67,11 @@ public:
         return ess_MultiplierDofs;
 	}
 
+    const mfem::Vector& GetRescaling() const noexcept
+    {
+        return CCT_inv_CBT1;
+    }
+
 private:
 
     bool IsSameOrient;
@@ -103,6 +108,8 @@ private:
     std::vector<std::unique_ptr<mfem::Vector>> Ainv_f;
     std::vector<std::unique_ptr<LDLCalculator>> Ainv;
     std::vector<std::unique_ptr<mfem::DenseMatrix>> A_el;
+
+    mfem::Vector CCT_inv_CBT1;
 
     mfem::Array<int> ess_HdivDofs;
     mfem::Array<int> ess_MultiplierDofs;

--- a/src/amge/HybridHdivL2.hpp
+++ b/src/amge/HybridHdivL2.hpp
@@ -109,6 +109,7 @@ private:
     std::vector<std::unique_ptr<DenseInverseCalculator>> Ainv;
     std::vector<std::unique_ptr<mfem::DenseMatrix>> A_el;
 
+    const mfem::Vector& L2_const_rep_;
     mfem::Vector CCT_inv_CBT1;
 
     mfem::Array<int> ess_HdivDofs;

--- a/src/linalg/factories/ParELAG_HybridizationSolverFactory.cpp
+++ b/src/linalg/factories/ParELAG_HybridizationSolverFactory.cpp
@@ -142,20 +142,22 @@ mfem::Vector HybridizationSolverFactory::_get_scaling_by_smoothing(
 {
     // Generate a diagonal scaling matrix by smoothing some random vector
     mfem::HypreSmoother smoother(const_cast<ParallelCSRMatrix&>(op));
-    mfem::CGSolver cg(op.GetComm());
-    cg.SetOperator(op);
-    cg.SetPreconditioner(smoother);
+    mfem::SLISolver sli(op.GetComm());
+    sli.SetOperator(op);
+    sli.SetPreconditioner(smoother);
 
     // Number of smoothing steps in the generation of the rescaling vector
     // If it is set to 0, then the original hybridized system is solved
-    cg.SetMaxIter(num_iter);
+    sli.SetMaxIter(num_iter);
 
     mfem::Vector scaling_vector(op.Height());
     scaling_vector = 1.0;
     mfem::Vector zeros(op.Height());
     zeros = 1e-8;
     if (num_iter > 0)
-        cg.Mult(zeros, scaling_vector);
+    {
+        sli.Mult(zeros, scaling_vector);
+    }
 
     return scaling_vector;
 }

--- a/src/linalg/factories/ParELAG_HybridizationSolverFactory.cpp
+++ b/src/linalg/factories/ParELAG_HybridizationSolverFactory.cpp
@@ -154,7 +154,7 @@ mfem::Vector HybridizationSolverFactory::_get_scaling_by_smoothing(
         sli.SetMaxIter(num_iter);
 
         mfem::Vector zeros(op.Height());
-        zeros = 1e-8;
+        zeros = 0.0;
         sli.Mult(zeros, scaling_vector);
     }
 

--- a/src/linalg/factories/ParELAG_HybridizationSolverFactory.cpp
+++ b/src/linalg/factories/ParELAG_HybridizationSolverFactory.cpp
@@ -90,10 +90,10 @@ std::unique_ptr<mfem::Solver> HybridizationSolverFactory::_do_build_block_solver
                 HB_mat_copy.EliminateRowCol(i);
         auto pHB_mat = Assemble(mult_dofTrueDof, HB_mat_copy, mult_dofTrueDof);
 
-        bool use_precomputed_scaling = true;
+        const bool use_precomputed_scaling = hybridization->GetRescaling().Size();
         const int rescale_iter = state.GetExtraParameter("RescaleIteration", 20);
         auto scaling_vector = use_precomputed_scaling ? hybridization->GetRescaling() :
-                             _get_scaling_by_smoothing(*pHB_mat, rescale_iter);
+                              _get_scaling_by_smoothing(*pHB_mat, rescale_iter);
 
         int* scale_i = new int[pHB_mat->Height()+1];
         int* scale_j = new int[pHB_mat->Height()];

--- a/src/linalg/factories/ParELAG_HybridizationSolverFactory.cpp
+++ b/src/linalg/factories/ParELAG_HybridizationSolverFactory.cpp
@@ -90,10 +90,11 @@ std::unique_ptr<mfem::Solver> HybridizationSolverFactory::_do_build_block_solver
                 HB_mat_copy.EliminateRowCol(i);
         auto pHB_mat = Assemble(mult_dofTrueDof, HB_mat_copy, mult_dofTrueDof);
 
-        const bool use_precomputed_scaling = hybridization->GetRescaling().Size();
-        const int rescale_iter = state.GetExtraParameter("RescaleIteration", 20);
+        const int rescale_iter = state.GetExtraParameter("RescaleIteration", -20);
+        const mfem::Vector& precomputed_scale = hybridization->GetRescaling();
+        const bool use_precomputed_scaling = precomputed_scale.Size() && rescale_iter < 0;
         auto scaling_vector = use_precomputed_scaling ? hybridization->GetRescaling() :
-                              _get_scaling_by_smoothing(*pHB_mat, rescale_iter);
+                              _get_scaling_by_smoothing(*pHB_mat, std::abs(rescale_iter));
 
         int* scale_i = new int[pHB_mat->Height()+1];
         int* scale_j = new int[pHB_mat->Height()];
@@ -140,22 +141,20 @@ std::unique_ptr<mfem::Solver> HybridizationSolverFactory::_do_build_block_solver
 mfem::Vector HybridizationSolverFactory::_get_scaling_by_smoothing(
      const ParallelCSRMatrix& op, int num_iter) const
 {
-    // Generate a diagonal scaling matrix by smoothing some random vector
-    mfem::HypreSmoother smoother(const_cast<ParallelCSRMatrix&>(op));
-    mfem::SLISolver sli(op.GetComm());
-    sli.SetOperator(op);
-    sli.SetPreconditioner(smoother);
-
-    // Number of smoothing steps in the generation of the rescaling vector
-    // If it is set to 0, then the original hybridized system is solved
-    sli.SetMaxIter(num_iter);
-
     mfem::Vector scaling_vector(op.Height());
     scaling_vector = 1.0;
-    mfem::Vector zeros(op.Height());
-    zeros = 1e-8;
+
     if (num_iter > 0)
     {
+        // Generate a diagonal scaling matrix by smoothing some random vector
+        mfem::HypreSmoother smoother(const_cast<ParallelCSRMatrix&>(op));
+        mfem::SLISolver sli(op.GetComm());
+        sli.SetOperator(op);
+        sli.SetPreconditioner(smoother);
+        sli.SetMaxIter(num_iter);
+
+        mfem::Vector zeros(op.Height());
+        zeros = 1e-8;
         sli.Mult(zeros, scaling_vector);
     }
 

--- a/src/linalg/factories/ParELAG_HybridizationSolverFactory.hpp
+++ b/src/linalg/factories/ParELAG_HybridizationSolverFactory.hpp
@@ -18,6 +18,7 @@
 #include "linalg/solver_core/ParELAG_BlockSolverFactory.hpp"
 #include "utilities/MemoryUtils.hpp"
 #include "linalg/utilities/ParELAG_MfemBlockOperator.hpp"
+#include "amge/HybridHdivL2.hpp"
 
 namespace parelag
 {
@@ -55,6 +56,9 @@ private:
     std::unique_ptr<mfem::Solver> _do_build_block_solver(
         const std::shared_ptr<MfemBlockOperator>& op,
         SolverState& state) const override;
+
+    mfem::Vector _get_scaling_by_smoothing(
+        const ParallelCSRMatrix& op, int num_iter) const;
 
     /// Sets any required parameters that have not already been set.
     void _do_set_default_parameters() override;

--- a/src/linalg/factories/ParELAG_HybridizationSolverFactory.hpp
+++ b/src/linalg/factories/ParELAG_HybridizationSolverFactory.hpp
@@ -57,6 +57,7 @@ private:
         const std::shared_ptr<MfemBlockOperator>& op,
         SolverState& state) const override;
 
+    /// Compute rescaling vector by smoothing
     mfem::Vector _get_scaling_by_smoothing(
         const ParallelCSRMatrix& op, int num_iter) const;
 


### PR DESCRIPTION
Two main changes:

1. add an alternative way to compute a rescaling vector: which is to set it as (CC^T)^{-1}C\widehat{B}^T * 1, where 1 is the coefficient vector of the constant one function in L2 space on a given level.

2. use `SLISolver` instead of `CGSolver` when computing rescaling vector by smoothing