### PR TITLE
Fixes Set and Get in the default parameters in the AMGe factory. Fixe…

### DIFF
--- a/examples/example_parameterlists/0form_example_parameters.xml
+++ b/examples/example_parameterlists/0form_example_parameters.xml
@@ -161,7 +161,7 @@
         <Parameter name="Interpolation type" type="int" value="6"/>
         <Parameter name="P max" type="int" value="4"/>
         <Parameter name="Print level" type="int" value="0"/>
-        <Parameter name="Dim" type="int" value="1"/>
+        <Parameter name="Number of functions" type="int" value="1"/>
         <Parameter name="Maximum levels" type="int" value="25"/>
         <Parameter name="Tolerance" type="double" value="0.0"/>
         <Parameter name="Maximum iterations" type="int" value="1"/>

--- a/examples/example_parameterlists/1form_example_parameters.xml
+++ b/examples/example_parameterlists/1form_example_parameters.xml
@@ -226,7 +226,7 @@
         <Parameter name="Interpolation type" type="int" value="6"/>
         <Parameter name="P max" type="int" value="4"/>
         <Parameter name="Print level" type="int" value="0"/>
-        <Parameter name="Dim" type="int" value="1"/>
+        <Parameter name="Number of functions" type="int" value="1"/>
         <Parameter name="Maximum levels" type="int" value="25"/>
         <Parameter name="Tolerance" type="double" value="0.0"/>
         <Parameter name="Maximum iterations" type="int" value="1"/>
@@ -255,7 +255,7 @@
           <Parameter name="Interpolation type" type="int" value="6"/>
           <Parameter name="P max" type="int" value="4"/>
           <Parameter name="Print level" type="int" value="0"/>
-          <Parameter name="Dim" type="int" value="1"/>
+          <Parameter name="Number of functions" type="int" value="1"/>
           <Parameter name="Maximum levels" type="int" value="25"/>
         </ParameterList>
         <!-- End ParameterList "PtAP AMG Parameters" -->
@@ -267,7 +267,7 @@
           <Parameter name="Interpolation type" type="int" value="6"/>
           <Parameter name="P max" type="int" value="4"/>
           <Parameter name="Print level" type="int" value="0"/>
-          <Parameter name="Dim" type="int" value="1"/>
+          <Parameter name="Number of functions" type="int" value="1"/>
           <Parameter name="Maximum levels" type="int" value="25"/>
         </ParameterList>
         <!-- End ParameterList "GtAG AMG Parameters" -->

--- a/examples/example_parameterlists/2form_example_parameters.xml
+++ b/examples/example_parameterlists/2form_example_parameters.xml
@@ -229,7 +229,7 @@
         <Parameter name="Interpolation type" type="int" value="6"/>
         <Parameter name="P max" type="int" value="4"/>
         <Parameter name="Print level" type="int" value="0"/>
-        <Parameter name="Dim" type="int" value="1"/>
+        <Parameter name="Number of functions" type="int" value="1"/>
         <Parameter name="Maximum levels" type="int" value="25"/>
         <Parameter name="Tolerance" type="double" value="0.0"/>
         <Parameter name="Maximum iterations" type="int" value="1"/>
@@ -256,7 +256,7 @@
           <Parameter name="Relaxation sweeps" type="int" value="1"/>
           <Parameter name="Relaxation weight" type="double" value="1.0"/>
           <Parameter name="Relaxation omega" type="double" value="1.0"/>
-          <Parameter name="beta_is_zero" type="bool" value="false"/>
+          <Parameter name="Beta is zero" type="bool" value="false"/>
           <ParameterList name="PtAP AMG Parameters">
             <Parameter name="Coarsening type" type="int" value="10"/>
             <Parameter name="Aggressive coarsening levels" type="int" value="1"/>
@@ -265,7 +265,7 @@
             <Parameter name="Interpolation type" type="int" value="6"/>
             <Parameter name="P max" type="int" value="4"/>
             <Parameter name="Print level" type="int" value="0"/>
-            <Parameter name="Dim" type="int" value="1"/>
+            <Parameter name="Number of functions" type="int" value="1"/>
             <Parameter name="Maximum levels" type="int" value="25"/>
           </ParameterList>
           <!-- End ParameterList "PtAP AMG Parameters" -->
@@ -279,7 +279,7 @@
           <Parameter name="Interpolation type" type="int" value="6"/>
           <Parameter name="P max" type="int" value="4"/>
           <Parameter name="Print level" type="int" value="0"/>
-          <Parameter name="Dim" type="int" value="1"/>
+          <Parameter name="Number of functions" type="int" value="1"/>
           <Parameter name="Maximum levels" type="int" value="25"/>
         </ParameterList>
         <!-- End ParameterList "AMG Parameters" -->

--- a/examples/example_parameterlists/darcy_example_parameters.xml
+++ b/examples/example_parameterlists/darcy_example_parameters.xml
@@ -154,7 +154,7 @@
         <Parameter name="Interpolation type" type="int" value="6"/>
         <Parameter name="P max" type="int" value="4"/>
         <Parameter name="Print level" type="int" value="0"/>
-        <Parameter name="Dim" type="int" value="1"/>
+        <Parameter name="Number of functions" type="int" value="1"/>
         <Parameter name="Maximum levels" type="int" value="25"/>
         <Parameter name="Tolerance" type="double" value="0.0"/>
         <Parameter name="Maximum iterations" type="int" value="1"/>

--- a/examples/testing_helpers/Create0FormParameterList.hpp
+++ b/examples/testing_helpers/Create0FormParameterList.hpp
@@ -61,7 +61,7 @@ std::unique_ptr<ParameterList> Create0FormTestParameters()
             {
                 auto& solver_list = list.Sublist("Solver Parameters");
                 solver_list.Set("Maximum levels",-1);
-                solver_list.Set("Forms",0);
+                solver_list.Set("Forms",std::vector<int>{0});
                 solver_list.Set("PreSmoother","Gauss-Seidel");
                 solver_list.Set("PostSmoother","Gauss-Seidel");
                 solver_list.Set("Coarse solver","CG_PCG-AMG");

--- a/examples/testing_helpers/Create1FormParameterList.hpp
+++ b/examples/testing_helpers/Create1FormParameterList.hpp
@@ -81,7 +81,7 @@ std::unique_ptr<ParameterList> Create1FormTestParameters()
             {
                 auto& solver_list = list.Sublist("Solver Parameters");
                 solver_list.Set("Maximum levels", -1);
-                solver_list.Set("Forms", 1);
+                solver_list.Set("Forms", std::vector<int>{1});
                 solver_list.Set("PreSmoother", "Hiptmair-GS-GS");
                 solver_list.Set("PostSmoother", "Hiptmair-GS-GS");
                 solver_list.Set("Coarse solver", "PCG-AMS");

--- a/examples/testing_helpers/Create2FormParameterList.hpp
+++ b/examples/testing_helpers/Create2FormParameterList.hpp
@@ -82,7 +82,7 @@ std::unique_ptr<ParameterList> Create2FormTestParameters()
             {
                 auto& solver_list = list.Sublist("Solver Parameters");
                 solver_list.Set("Maximum levels", -1);
-                solver_list.Set("Forms", 2);
+                solver_list.Set("Forms", std::vector<int>{2});
                 solver_list.Set("PreSmoother", "Hiptmair-GS-GS");
                 solver_list.Set("PostSmoother", "Hiptmair-GS-GS");
                 solver_list.Set("Coarse solver", "PCG-ADS");

--- a/examples/testing_helpers/CreateDarcyParameterList.hpp
+++ b/examples/testing_helpers/CreateDarcyParameterList.hpp
@@ -61,7 +61,7 @@ std::unique_ptr<ParameterList> CreateDarcyTestParameters()
             list.Set("Type", "Hybridization");
             {
                 auto& solver_list = list.Sublist("Solver Parameters");
-                solver_list.Set("Forms", "2 3");
+                solver_list.Set("Forms", std::vector<int>{2, 3});
                 solver_list.Set("Solver", "CG_PCG-AMG");
                 solver_list.Set("RescaleIteration", 1);
             }

--- a/src/linalg/factories/ParELAG_ADSSolverFactory.cpp
+++ b/src/linalg/factories/ParELAG_ADSSolverFactory.cpp
@@ -44,11 +44,14 @@ void ADSSolverFactory::_do_set_default_parameters()
 
     ParameterList& ams_params = params.Sublist("AMS Parameters");
     ams_params.Get<int>("Cycle type", 14);
+
+    // NB: These do not seem to be used in this context.
+    //     They would have been used in an actual AMS factory.
     ams_params.Get<int>("Relaxation type", 2);
     ams_params.Get<int>("Relaxation sweeps", 1);
     ams_params.Get<double>("Relaxation weight", 1.0);
     ams_params.Get<double>("Relaxation omega", 1.0);
-    ams_params.Get<bool>("beta_is_zero", false);
+    ams_params.Get<bool>("Beta is zero", false);
 
     ParameterList& ptap_mg_params = ams_params.Sublist("PtAP AMG Parameters");
     ptap_mg_params.Get<int>("Coarsening type", 10);
@@ -57,10 +60,15 @@ void ADSSolverFactory::_do_set_default_parameters()
     ptap_mg_params.Get<double>("Theta", 0.25);
     ptap_mg_params.Get<int>("Interpolation type", 6);
     ptap_mg_params.Get<int>("P max", 4);
+
+    // NB: These do not seem to be used in this context.
+    //     They would have been used in an actual BoomerAMG factory.
     ptap_mg_params.Get<int>("Print level", 0);
-    ptap_mg_params.Get<int>("Dim", 1);
+    ptap_mg_params.Get<int>("Number of functions", 1);
     ptap_mg_params.Get<int>("Maximum levels", 25);
 
+    // NB: These do not seem to be used in this context.
+    //     They would have been used in an actual AMS factory.
     ParameterList& gtag_mg_params = ams_params.Sublist("GtAG AMG Parameters");
     gtag_mg_params.Get<int>("Coarsening type", 10);
     gtag_mg_params.Get<int>("Aggressive coarsening levels", 1);
@@ -68,8 +76,11 @@ void ADSSolverFactory::_do_set_default_parameters()
     gtag_mg_params.Get<double>("Theta", 0.25);
     gtag_mg_params.Get<int>("Interpolation type", 6);
     gtag_mg_params.Get<int>("P max", 4);
+
+    // NB: These would not have been used even in an actual AMS factory,
+    //     but would have been used in an actual BoomerAMG factory.
     gtag_mg_params.Get<int>("Print level", 0);
-    gtag_mg_params.Get<int>("Dim", 1);
+    gtag_mg_params.Get<int>("Number of functions", 1);
     gtag_mg_params.Get<int>("Maximum levels", 25);
 
     ParameterList& amg_params = params.Sublist("AMG Parameters");
@@ -79,8 +90,11 @@ void ADSSolverFactory::_do_set_default_parameters()
     amg_params.Get<double>("Theta", 0.25);
     amg_params.Get<int>("Interpolation type", 6);
     amg_params.Get<int>("P max", 4);
+
+    // NB: These do not seem to be used in this context.
+    //     They would have been used in an actual BoomerAMG factory.
     amg_params.Get<int>("Print level", 0);
-    amg_params.Get<int>("Dim", 1);
+    amg_params.Get<int>("Number of functions", 1);
     amg_params.Get<int>("Maximum levels", 25);
 }
 

--- a/src/linalg/factories/ParELAG_ADSSolverFactory.cpp
+++ b/src/linalg/factories/ParELAG_ADSSolverFactory.cpp
@@ -45,7 +45,7 @@ void ADSSolverFactory::_do_set_default_parameters()
     ParameterList& ams_params = params.Sublist("AMS Parameters");
     ams_params.Get<int>("Cycle type", 14);
 
-    // NB: These do not seem to be used in this context.
+    // NB: These do not seem to be used in this context (i.e., in ADSSolverWrapper).
     //     They would have been used in an actual AMS factory.
     ams_params.Get<int>("Relaxation type", 2);
     ams_params.Get<int>("Relaxation sweeps", 1);
@@ -61,13 +61,13 @@ void ADSSolverFactory::_do_set_default_parameters()
     ptap_mg_params.Get<int>("Interpolation type", 6);
     ptap_mg_params.Get<int>("P max", 4);
 
-    // NB: These do not seem to be used in this context.
+    // NB: These do not seem to be used in this context (i.e., in ADSSolverWrapper).
     //     They would have been used in an actual BoomerAMG factory.
     ptap_mg_params.Get<int>("Print level", 0);
     ptap_mg_params.Get<int>("Number of functions", 1);
     ptap_mg_params.Get<int>("Maximum levels", 25);
 
-    // NB: These do not seem to be used in this context.
+    // NB: These do not seem to be used in this context (i.e., in ADSSolverWrapper).
     //     They would have been used in an actual AMS factory.
     ParameterList& gtag_mg_params = ams_params.Sublist("GtAG AMG Parameters");
     gtag_mg_params.Get<int>("Coarsening type", 10);
@@ -77,7 +77,7 @@ void ADSSolverFactory::_do_set_default_parameters()
     gtag_mg_params.Get<int>("Interpolation type", 6);
     gtag_mg_params.Get<int>("P max", 4);
 
-    // NB: These would not have been used even in an actual AMS factory,
+    // NB: These would not have been used even in an actual AMS factory (more precisely, in AMSSolverWrapper),
     //     but would have been used in an actual BoomerAMG factory.
     gtag_mg_params.Get<int>("Print level", 0);
     gtag_mg_params.Get<int>("Number of functions", 1);
@@ -91,7 +91,7 @@ void ADSSolverFactory::_do_set_default_parameters()
     amg_params.Get<int>("Interpolation type", 6);
     amg_params.Get<int>("P max", 4);
 
-    // NB: These do not seem to be used in this context.
+    // NB: These do not seem to be used in this context (i.e., in ADSSolverWrapper).
     //     They would have been used in an actual BoomerAMG factory.
     amg_params.Get<int>("Print level", 0);
     amg_params.Get<int>("Number of functions", 1);

--- a/src/linalg/factories/ParELAG_AMGeSolverFactory.hpp
+++ b/src/linalg/factories/ParELAG_AMGeSolverFactory.hpp
@@ -72,8 +72,8 @@ private:
     void _do_set_default_parameters() override
     {
         auto& params = GetParameters();
-        params.Set("Maximum levels",-1);
-        params.Set("Forms",std::vector<int>());
+        params.Get<int>("Maximum levels",-1);
+        params.Get<std::vector<int>>("Forms",std::vector<int>());
     }
 
     /** \brief Implementation of Initialize(). */

--- a/src/linalg/factories/ParELAG_AMSSolverFactory.cpp
+++ b/src/linalg/factories/ParELAG_AMSSolverFactory.cpp
@@ -38,7 +38,7 @@ void AMSSolverFactory::_do_set_default_parameters()
     params.Get<int>("Relaxation sweeps", 1);
     params.Get<double>("Relaxation weight", 1.0);
     params.Get<double>("Relaxation omega", 1.0);
-    params.Get<bool>("beta_is_zero", false);
+    params.Get<bool>("Beta is zero", false);
 
     ParameterList& ptap_mg_params = params.Sublist("PtAP AMG Parameters");
     ptap_mg_params.Get<int>("Coarsening type", 10);
@@ -47,8 +47,11 @@ void AMSSolverFactory::_do_set_default_parameters()
     ptap_mg_params.Get<double>("Theta", 0.25);
     ptap_mg_params.Get<int>("Interpolation type", 6);
     ptap_mg_params.Get<int>("P max", 4);
+
+    // NB: These do not seem to be used in this context.
+    //     They would have been used in an actual BoomerAMG factory.
     ptap_mg_params.Get<int>("Print level", 0);
-    ptap_mg_params.Get<int>("Dim", 1);
+    ptap_mg_params.Get<int>("Number of functions", 1);
     ptap_mg_params.Get<int>("Maximum levels", 25);
 
     ParameterList& gtag_mg_params = params.Sublist("GtAG AMG Parameters");
@@ -58,8 +61,11 @@ void AMSSolverFactory::_do_set_default_parameters()
     gtag_mg_params.Get<double>("Theta", 0.25);
     gtag_mg_params.Get<int>("Interpolation type", 6);
     gtag_mg_params.Get<int>("P max", 4);
+
+    // NB: These do not seem to be used in this context.
+    //     They would have been used in an actual BoomerAMG factory.
     gtag_mg_params.Get<int>("Print level", 0);
-    gtag_mg_params.Get<int>("Dim", 1);
+    gtag_mg_params.Get<int>("Number of functions", 1);
     gtag_mg_params.Get<int>("Maximum levels", 25);
 
 }

--- a/src/linalg/factories/ParELAG_AMSSolverFactory.cpp
+++ b/src/linalg/factories/ParELAG_AMSSolverFactory.cpp
@@ -48,7 +48,7 @@ void AMSSolverFactory::_do_set_default_parameters()
     ptap_mg_params.Get<int>("Interpolation type", 6);
     ptap_mg_params.Get<int>("P max", 4);
 
-    // NB: These do not seem to be used in this context.
+    // NB: These do not seem to be used in this context (i.e., in AMSSolverWrapper).
     //     They would have been used in an actual BoomerAMG factory.
     ptap_mg_params.Get<int>("Print level", 0);
     ptap_mg_params.Get<int>("Number of functions", 1);
@@ -62,7 +62,7 @@ void AMSSolverFactory::_do_set_default_parameters()
     gtag_mg_params.Get<int>("Interpolation type", 6);
     gtag_mg_params.Get<int>("P max", 4);
 
-    // NB: These do not seem to be used in this context.
+    // NB: These do not seem to be used in this context (i.e., in AMSSolverWrapper).
     //     They would have been used in an actual BoomerAMG factory.
     gtag_mg_params.Get<int>("Print level", 0);
     gtag_mg_params.Get<int>("Number of functions", 1);

--- a/src/linalg/solver_ops/ParELAG_BoomerAMGSolverWrapper.cpp
+++ b/src/linalg/solver_ops/ParELAG_BoomerAMGSolverWrapper.cpp
@@ -63,7 +63,7 @@ void BoomerAMGSolverWrapper::_do_set_parameters(ParameterList& Params)
     HYPRE_BoomerAMGSetMaxIter(
         amg_h, Params.Get<int>("Maximum iterations",1));
     HYPRE_BoomerAMGSetStrongThreshold(
-        amg_h, Params.Get<double>("Thta",0.25));
+        amg_h, Params.Get<double>("Theta",0.25));
     HYPRE_BoomerAMGSetInterpType(
         amg_h, Params.Get<int>("Interpolation type",6));
     HYPRE_BoomerAMGSetPMaxElmts(

--- a/src/linalg/solver_ops/ParELAG_Hierarchy.hpp
+++ b/src/linalg/solver_ops/ParELAG_Hierarchy.hpp
@@ -287,7 +287,7 @@ private:
     /** \brief The cycle strategy for each level. */
     std::vector<int> CycleMu_;
 
-    /** \brief \c true of we should use \f$R=P^T\f$. */
+    /** \brief \c true if we should use \f$R=P^T\f$. */
     bool ImplicitTranspose_;
 
     /** \name Auxiliary vectors */


### PR DESCRIPTION
…s some parameter naming errors and typos. Adds some comments about parameters.

Addresses #8 for AMGe by replacing Set with Get + default value. Also, it fixes some parameter naming issues and adds a few clarifying comments in the code.

It successfully passes `make test`.