### PR TITLE
Fix parameter setting for AMS. This brings small changes to behavior,…

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -151,9 +151,9 @@ u l2-like errors: 5.4999e-04 2.1996e-04 \np l2-like errors: 9.9192e-03 4.5006e-0
   set_tests_properties(MG1Form
     PROPERTIES
     PASS_REGULAR_EXPRESSION
-    "Final residual norm: 1.972e-06;\
-Final residual norm: 5.01907e-07;\
-Final residual norm: 1.36919e-06")
+    "Final residual norm: 1.97197e-06;\
+Final residual norm: 5.01914e-07;\
+Final residual norm: 1.36916e-06")
 
   add_test(MG2Form MultigridTest2Form.exe)
   set_tests_properties(MG2Form

--- a/src/linalg/solver_ops/ParELAG_AMSSolverWrapper.cpp
+++ b/src/linalg/solver_ops/ParELAG_AMSSolverWrapper.cpp
@@ -85,7 +85,7 @@ void AMSSolverWrapper::_do_set_parameters(ParameterList& Params)
 
     if (not Params.Get<bool>("Beta is zero", false))
     {
-        HYPRE_AMSSetAlphaAMGOptions(
+        HYPRE_AMSSetBetaAMGOptions(
             ams_, gtag_mg_params.Get<int>("Coarsening type",10),
             gtag_mg_params.Get<int>("Aggressive coarsening levels",1),
             gtag_mg_params.Get<int>("Relaxation type",6),


### PR DESCRIPTION
… because parameters that did not kick in befor are now accounted for. Thus, one of the tests was adjusted properly.

Fixes #10. Note that `make test` succeeds.