### PR TITLE
Fix big J in hypre_CSRMatrixAdd2

### DIFF
--- a/src/hypreExtension/parcsr-add.c
+++ b/src/hypreExtension/parcsr-add.c
@@ -98,7 +98,7 @@ hypre_CSRMatrixAdd2( double a, hypre_CSRMatrix *A,
    HYPRE_Int         ncols_B  = hypre_CSRMatrixNumCols(B);
    hypre_CSRMatrix  *C;
    double           *C_data;
-   HYPRE_Int	     *C_i;
+   HYPRE_Int        *C_i;
 #if MFEM_HYPRE_VERSION >= 21600
    HYPRE_BigInt     *C_j;
 #else


### PR DESCRIPTION
For hypre v2.16 or later,  the column array of the CSR matrix returned from `hypre_MergeDiagAndOffd` is stored in `big_j` instead of `j`. This causes seg fault in `hypre_CSRMatrixAdd2` (this is called after `hypre_MergeDiagAndOffd` in `hypre_ParCSRMatrixAdd2`). This PR fixes that by making the extraction of column array dependent on hypre version.

P.S.: it is just a simple fix, ideally `hypre_CSRMatrixAdd2` should be able to handle normal `j`, but right now we are assuming the input matrices in `hypre_CSRMatrixAdd2` are all using `big_j` if hypre >= v2.16 (note that the output still uses normal `j`), which is ok for our purpose as it is only used in `hypre_ParCSRMatrixAdd2`. 